### PR TITLE
add scm.id since wso2 parent is not used.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -357,6 +357,7 @@
         <maven.docker.version>1.4.10</maven.docker.version>
 
         <docker.repo.name>celleryio</docker.repo.name>
+        <project.scm.id>my-scm-server</project.scm.id>
     </properties>
 
 </project>


### PR DESCRIPTION
## Purpose
> add scm.id since wso2 parent is not used.