### PR TITLE
implement DCR for webcell gateway 🎉

### DIFF
--- a/components/envoy-oidc-filter/main.go
+++ b/components/envoy-oidc-filter/main.go
@@ -21,7 +21,7 @@ const (
 	clientSecretEnv            = "CLIENT_SECRET"
 	redirectUrlEnv             = "REDIRECT_URL"
 	appUrlEnv                  = "APP_BASE_URL"
-	dcrEpEnv                   = "DCR_EP"
+	dcrEpEnv                   = "DCR_ENDPOINT"
 	dcrUser                    = "DCR_USER"
 	dcrPassword                = "DCR_PASSWORD"
 )
@@ -49,7 +49,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	auth, err := oidc.NewAuthenticator(*cfg)
+	auth, err := oidc.NewAuthenticator(cfg)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/components/envoy-oidc-filter/oidc/config.go
+++ b/components/envoy-oidc-filter/oidc/config.go
@@ -1,7 +1,12 @@
 package oidc
 
+import "github.com/pkg/errors"
+
 type Config struct {
 	Provider     string
+	DcrEP        string
+	DcrUser      string
+	DcrPassword  string
 	ClientID     string
 	ClientSecret string
 	RedirectURL  string
@@ -9,5 +14,31 @@ type Config struct {
 }
 
 func (c *Config) Validate() error {
+	if IsEmpty(c.Provider)  {
+		return createErr("Identity provider not found in OIDC config")
+	}
+	if IsEmpty(c.ClientID) {
+		return createErr("Client id not found in OIDC config")
+	}
+	if IsEmpty(c.ClientSecret)  {
+		// check if DCR configs are provided
+		if IsEmpty(c.DcrEP) || IsEmpty(c.DcrUser) || IsEmpty(c.DcrPassword) {
+			return createErr("Either Client Id & Client Secret or DCR endpoint & credentials should be provided in OIDC config")
+		}
+	}
+	if IsEmpty(c.RedirectURL)  {
+		return createErr("Redirect Url not found in OIDC config")
+	}
+	if IsEmpty(c.BaseURL)  {
+		return createErr("Base Url not found in OIDC config")
+	}
 	return nil
+}
+
+func IsEmpty(str string) bool {
+	return len(str) == 0
+}
+
+func createErr (err string) error {
+	return errors.New(err)
 }

--- a/components/envoy-oidc-filter/oidc/dcr.go
+++ b/components/envoy-oidc-filter/oidc/dcr.go
@@ -20,7 +20,6 @@ package oidc
 
 import (
 	"bytes"
-	"crypto/tls"
 	"encoding/json"
 	"github.com/pkg/errors"
 	"io/ioutil"
@@ -43,9 +42,6 @@ func isDcrRequired(c *Config) bool {
 }
 
 func dcr(c *Config) (string, string, error) {
-
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-
 	values := map[string]interface{}{"client_name": c.ClientID, "grant_types": []string{"password",
 		"authorization_code", "implicit"}, "ext_param_client_id": c.ClientID, "redirect_uris": []string{c.RedirectURL}}
 

--- a/components/envoy-oidc-filter/oidc/dcr.go
+++ b/components/envoy-oidc-filter/oidc/dcr.go
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2019 WSO2 Inc. (http:www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http:www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package oidc
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"github.com/pkg/errors"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+)
+
+const (
+	contentTypeHeader = "Content-Type"
+	contentTypeJson   = "application/json"
+)
+
+func isDcrRequired(c *Config) bool {
+	if !IsEmpty(c.ClientID) && !IsEmpty(c.ClientSecret) {
+		// client id and client secret provided, DCR not required
+		return false
+	}
+	return true
+}
+
+func dcr(c *Config) (string, string, error) {
+
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+
+	values := map[string]interface{}{"client_name": c.ClientID, "grant_types": []string{"password",
+		"authorization_code", "implicit"}, "ext_param_client_id": c.ClientID, "redirect_uris": []string{c.RedirectURL}}
+
+	payload, err := json.Marshal(values)
+	if err != nil {
+		return "", "", err
+	}
+	log.Printf("DCR payload: " + string(payload))
+
+	req, err := http.NewRequest("POST", c.DcrEP, bytes.NewBuffer(payload))
+	if err != nil {
+		return "", "", err
+	}
+	req.SetBasicAuth(c.DcrUser, c.DcrPassword)
+	req.Header.Set(contentTypeHeader, contentTypeJson)
+	client := http.DefaultClient
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", err
+	}
+
+	var clientSecret string
+	if (resp.StatusCode != 201) {
+		if resp.StatusCode == 400 {
+			var errResp dcrErrorResponse
+			err = json.Unmarshal(body, &errResp)
+			if err != nil {
+				return "", "", err
+			}
+			// check if this is due to oauth application already exist error
+			if errResp.Error == "invalid_client_metadata" {
+				log.Printf("Bad request while attempting DCR: %v", errResp.ErrorDescription)
+				// try to retrieve if exists
+				clientSecret, err = getClientSecret(c)
+				if err != nil {
+					return "", "", err
+				}
+			}
+		} else {
+			log.Printf("Error occurred while attempting DCR: %+v" + string(body))
+		}
+	} else {
+		var successResp dcrSuccessResponse
+		err = json.Unmarshal(body, &successResp)
+		if err != nil {
+			return "", "", err
+		}
+		clientSecret = successResp.ClientSecret
+	}
+	return c.ClientID, clientSecret, nil
+}
+
+func getClientSecret(c *Config) (string, error) {
+	req, err := http.NewRequest("GET", strings.TrimSuffix(c.DcrEP, "/")+"?client_name="+
+		c.ClientID, nil)
+	if err != nil {
+		return "", err
+	}
+	req.SetBasicAuth(c.DcrUser, c.DcrPassword)
+	req.Header.Set(contentTypeHeader, contentTypeJson)
+	client := http.DefaultClient
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	var clientSecret string
+	if resp.StatusCode != 200 {
+		// error
+		return "", errors.Errorf("Error occurred while retrieving oauth application %v, error: %+v",
+			c.ClientID, body)
+	} else {
+		var successResp dcrSuccessResponse
+		err = json.Unmarshal(body, &successResp)
+		if err != nil {
+			return "", err
+		}
+		log.Printf("Retrieved Oauth app with client name: %v, client id %v", successResp.ClientName,
+			successResp.ClientId)
+		clientSecret = successResp.ClientSecret
+	}
+	return clientSecret, nil
+}

--- a/components/envoy-oidc-filter/oidc/oidc.go
+++ b/components/envoy-oidc-filter/oidc/oidc.go
@@ -21,13 +21,13 @@ const (
 )
 
 type dcrErrorResponse struct {
-	Error string `json:"error"`
+	Error            string `json:"error"`
 	ErrorDescription string `json:"error_description"`
 }
 
 type dcrSuccessResponse struct {
-	ClientName string `json:"client_name"`
-	ClientId string `json:"client_id"`
+	ClientName   string `json:"client_name"`
+	ClientId     string `json:"client_id"`
 	ClientSecret string `json:"client_secret"`
 }
 
@@ -40,16 +40,16 @@ type Authenticator struct {
 	unsecuredPaths map[string]bool
 }
 
-func NewAuthenticator(c Config) (*Authenticator, error) {
+func NewAuthenticator(c *Config) (*Authenticator, error) {
 	ctx := context.Background()
 	provider, err := oidc.NewProvider(ctx, c.Provider)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get provider: %v", err)
 	}
 
-	if isDcrRequired(&c) {
+	if isDcrRequired(c) {
 		log.Println("DCR required")
-		clientId, clientSecret, err := dcr(&c)
+		clientId, clientSecret, err := dcr(c)
 		if err != nil {
 			return nil, fmt.Errorf("Error in performing DCR: %v", err)
 		}
@@ -73,7 +73,7 @@ func NewAuthenticator(c Config) (*Authenticator, error) {
 		oauth2Config: config,
 		oidcConfig:   oidcConfig,
 		ctx:          ctx,
-		config:       &c,
+		config:       c,
 		// TODO:
 		// unsecuredPaths: map[string]bool{
 		//	"/pet/app/*": true,


### PR DESCRIPTION
## Purpose
> This implements DCR for the webcell gateway. A user can either provide the DCR url and credentials, or the client id & client secret of a previously created application. 

The following environment variables are required for DCR:

- IDP_DISCOVERY_URL=https:///<IDP_HOST>/oauth2/token
- CLIENT_ID=xxxxxxxx
- DCR_ENDPOINT=https://<IDP_HOST>/api/identity/oauth2/dcr/v1.1/register
- DCR_USER=user
- DCR_PASSWORD=********* 
- SKIP_DISCOVERY_URL_CERT_VERIFY=true
- REDIRECT_URL=http://my-domain.com/_auth/callback
- APP_BASE_URL=http://my-domain.com/pet/

The following environment variables are required when providing client id and secret: 

- IDP_DISCOVERY_URL=https:///<IDP_URL>/oauth2/token
- CLIENT_ID=xxxxxxxx
- CLIENT_SECRET=yyyyyyy
- SKIP_DISCOVERY_URL_CERT_VERIFY=true
- REDIRECT_URL=http://my-domain.com/_auth/callback
- APP_BASE_URL=http://my-domain.com/pet/

