### PR TITLE
Add missing ca certs to the envoy-oidc-filter docker image

### DIFF
--- a/docker/envoy-oidc-filter/Dockerfile
+++ b/docker/envoy-oidc-filter/Dockerfile
@@ -1,3 +1,8 @@
+FROM alpine:latest as certs
+RUN apk --update add ca-certificates
+
+
 FROM scratch
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY envoy-oidc-filter /
 ENTRYPOINT ["/envoy-oidc-filter"]


### PR DESCRIPTION
Add missing ca certs to the envoy-oidc-filter docker image