### PR TITLE
Support non secured paths in web cells

### DIFF
--- a/components/envoy-oidc-filter/main.go
+++ b/components/envoy-oidc-filter/main.go
@@ -53,7 +53,7 @@ func main() {
 		DcrEP:           os.Getenv(DcrEpEnv),
 		DcrUser:         os.Getenv(DcrUser),
 		DcrPassword:     os.Getenv(DcrPassword),
-		NonSecurePaths:  getNonSecuredPaths(),
+		NonSecurePaths:  getNonSecurePaths(),
 		PrivateKeyFile:  os.Getenv(PrivateKeyFile),
 		CertificateFile: os.Getenv(CertificateFile),
 		JwtIssuer:       os.Getenv(JwtIssuer),
@@ -103,7 +103,7 @@ func LookupEnv(key string, fallback string) string {
 	return fallback
 }
 
-func getNonSecuredPaths() []string {
+func getNonSecurePaths() []string {
 	_, exist := os.LookupEnv(NonSecurePaths); if !exist {
 		return nil
 	}
@@ -111,6 +111,7 @@ func getNonSecuredPaths() []string {
 	paths := make([]string, len(elems))
 	for i, elem := range elems {
 		paths[i] = strings.TrimSpace(elem)
+		fmt.Printf("Non secure path: %v\n", paths[i])
 	}
 	return paths
 }

--- a/components/envoy-oidc-filter/main.go
+++ b/components/envoy-oidc-filter/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 
 	"github.com/cellery-io/mesh-security/components/envoy-oidc-filter/oidc"
 	ext_authz "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2alpha"
@@ -25,14 +26,14 @@ const (
 	DcrEpEnv                   = "DCR_ENDPOINT"
 	DcrUser                    = "DCR_USER"
 	DcrPassword                = "DCR_PASSWORD"
+	NonSecurePaths             = "NON_SECURE_PATHS"
 	PrivateKeyFile             = "PRIVATE_KEY_FILE"
 	CertificateFile            = "CERTIFICATE_FILE"
 	JwtIssuer                  = "JWT_ISSUER"
 	JwtAudience                = "JWT_AUDIENCE"
 	SubjectClaim               = "SUBJECT_CLAIM"
-
-	FilterListenerPort       = "FILTER_LISTENER_PORT"
-	HttpCallbackListenerPort = "HTTP_CALLBACK_LISTENER_PORT"
+	FilterListenerPort         = "FILTER_LISTENER_PORT"
+	HttpCallbackListenerPort   = "HTTP_CALLBACK_LISTENER_PORT"
 )
 
 func main() {
@@ -52,6 +53,7 @@ func main() {
 		DcrEP:           os.Getenv(DcrEpEnv),
 		DcrUser:         os.Getenv(DcrUser),
 		DcrPassword:     os.Getenv(DcrPassword),
+		NonSecurePaths:  getNonSecuredPaths(),
 		PrivateKeyFile:  os.Getenv(PrivateKeyFile),
 		CertificateFile: os.Getenv(CertificateFile),
 		JwtIssuer:       os.Getenv(JwtIssuer),
@@ -99,4 +101,16 @@ func LookupEnv(key string, fallback string) string {
 		return value
 	}
 	return fallback
+}
+
+func getNonSecuredPaths() []string {
+	_, exist := os.LookupEnv(NonSecurePaths); if !exist {
+		return nil
+	}
+	elems := strings.Split(os.Getenv(NonSecurePaths), ",")
+	paths := make([]string, len(elems))
+	for i, elem := range elems {
+		paths[i] = strings.TrimSpace(elem)
+	}
+	return paths
 }

--- a/components/envoy-oidc-filter/oidc/config.go
+++ b/components/envoy-oidc-filter/oidc/config.go
@@ -7,6 +7,7 @@ type Config struct {
 	DcrEP           string
 	DcrUser         string
 	DcrPassword     string
+	NonSecurePaths  []string
 	ClientID        string
 	ClientSecret    string
 	RedirectURL     string

--- a/components/envoy-oidc-filter/oidc/oidc.go
+++ b/components/envoy-oidc-filter/oidc/oidc.go
@@ -113,10 +113,9 @@ func (a *Authenticator) Check(ctx context.Context, checkReq *extauthz.CheckReque
 
 	// if this is an unsecured path, skip re-auth
 	if a.config.NonSecurePaths != nil && isUnsecurePath(req.URL.Path, a.config.NonSecurePaths) {
-		fmt.Println("***** non secured path: " + req.URL.Path)
+		//fmt.Println("***** non secured path: " + req.URL.Path)
 		return buildOkCheckResponseWithoutAuthAndSub(), nil
 	}
-	fmt.Println("******* No unsecure paths found !!")
 
 	if cookie, err := req.Cookie(IdTokenCookie); err == nil {
 		_, err := a.provider.Verifier(a.oidcConfig).Verify(a.ctx, cookie.Value)
@@ -199,8 +198,8 @@ func isUnsecurePath(requestPath string, nonSecuredPaths []string) bool {
 		// check if an absolute path. ex: /pet or /pet/
 		if !strings.HasSuffix(nonSecPath, "*") {
 			if path.Clean(requestPath) == path.Clean(nonSecPath) {
-				fmt.Println("***** pattern: " + nonSecPath)
-				fmt.Println("***** matched request path: " + path.Clean(requestPath))
+				//fmt.Println("***** pattern: " + nonSecPath)
+				//fmt.Println("***** matched request path: " + path.Clean(requestPath))
 				return true
 			}
 		} else {
@@ -212,8 +211,8 @@ func isUnsecurePath(requestPath string, nonSecuredPaths []string) bool {
 			// If not, can't compare.
 			if nonSecPathLength <= len(requestPath) {
 				if path.Clean(requestPath[:nonSecPathLength]) == path.Clean(pathWithouthoutTrailingStar) {
-					fmt.Println("***** pattern: " + nonSecPath)
-					fmt.Println("***** matched request path segment: " + path.Clean(requestPath[:nonSecPathLength]))
+					//fmt.Println("***** pattern: " + nonSecPath)
+					//fmt.Println("***** matched request path segment: " + path.Clean(requestPath[:nonSecPathLength]))
 					return true
 				}
 			}

--- a/components/envoy-oidc-filter/oidc/oidc.go
+++ b/components/envoy-oidc-filter/oidc/oidc.go
@@ -95,11 +95,6 @@ func NewAuthenticator(c *Config) (*Authenticator, error) {
 		config:       c,
 		key:          key,
 		cert:         cert,
-		// TODO:
-		// unsecuredPaths: map[string]bool{
-		//	"/pet/app/*": true,
-		//	"/pet/":      true,
-		//},
 	}, nil
 }
 
@@ -112,7 +107,7 @@ func (a *Authenticator) Check(ctx context.Context, checkReq *extauthz.CheckReque
 	}
 
 	// if this is an unsecured path, skip re-auth
-	if a.config.NonSecurePaths != nil && isUnsecurePath(req.URL.Path, a.config.NonSecurePaths) {
+	if a.config.NonSecurePaths != nil && isNonSecurePath(req.URL.Path, a.config.NonSecurePaths) {
 		//fmt.Println("***** non secured path: " + req.URL.Path)
 		return buildOkCheckResponseWithoutAuthAndSub(), nil
 	}
@@ -193,7 +188,7 @@ func (a *Authenticator) Callback(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func isUnsecurePath(requestPath string, nonSecuredPaths []string) bool {
+func isNonSecurePath(requestPath string, nonSecuredPaths []string) bool {
 	for _, nonSecPath := range nonSecuredPaths {
 		// check if an absolute path. ex: /pet or /pet/
 		if !strings.HasSuffix(nonSecPath, "*") {


### PR DESCRIPTION
## Purpose
> Non secured paths can be specified with the environment variable NON_SECURE_PATHS, as a comma separated list. Exact path matches and wildcards with /* are supported.

Ex.: NON_SECURE_PATHS=/items,/items/app/*