### PR TITLE
support explicit secured paths in oidc filter

### DIFF
--- a/components/envoy-oidc-filter/main.go
+++ b/components/envoy-oidc-filter/main.go
@@ -28,6 +28,7 @@ const (
 	DcrUser                    = "DCR_USER"
 	DcrPassword                = "DCR_PASSWORD"
 	NonSecurePaths             = "NON_SECURE_PATHS"
+	SecurePaths                = "SECURE_PATHS"
 	PrivateKeyFile             = "PRIVATE_KEY_FILE"
 	CertificateFile            = "CERTIFICATE_FILE"
 	JwtIssuer                  = "JWT_ISSUER"
@@ -56,6 +57,7 @@ func main() {
 		DcrUser:         os.Getenv(DcrUser),
 		DcrPassword:     os.Getenv(DcrPassword),
 		NonSecurePaths:  getNonSecurePaths(),
+		SecurePaths:     getSecurePaths(),
 		PrivateKeyFile:  os.Getenv(PrivateKeyFile),
 		CertificateFile: os.Getenv(CertificateFile),
 		JwtIssuer:       os.Getenv(JwtIssuer),
@@ -106,9 +108,21 @@ func LookupEnv(key string, fallback string) string {
 	return fallback
 }
 
+func getSecurePaths() []string {
+	_, exist := os.LookupEnv(SecurePaths); if !exist || len(os.Getenv(SecurePaths)) == 0 {
+		return nil
+	}
+	elems := strings.Split(os.Getenv(SecurePaths), ",")
+	paths := make([]string, len(elems))
+	for i, elem := range elems {
+		paths[i] = strings.TrimSpace(elem)
+	}
+	fmt.Printf("secure paths: [ %v ] \n", paths)
+	return paths
+}
+
 func getNonSecurePaths() []string {
-	_, exist := os.LookupEnv(NonSecurePaths)
-	if !exist {
+	_, exist := os.LookupEnv(NonSecurePaths); if !exist || len(os.Getenv(NonSecurePaths)) == 0 {
 		return nil
 	}
 	elems := strings.Split(os.Getenv(NonSecurePaths), ",")

--- a/components/envoy-oidc-filter/oidc/config.go
+++ b/components/envoy-oidc-filter/oidc/config.go
@@ -1,6 +1,9 @@
 package oidc
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 type Config struct {
 	Provider        string
@@ -8,6 +11,7 @@ type Config struct {
 	DcrUser         string
 	DcrPassword     string
 	NonSecurePaths  []string
+	SecurePaths     []string
 	ClientID        string
 	ClientSecret    string
 	RedirectURL     string
@@ -56,7 +60,17 @@ func (c *Config) Validate() error {
 		return createErr("jwt audience cannot be empty")
 	}
 
+	// check if both secured and non-secured URLs are provided.
+	// If so, only non-secured URLs will be unprotected, while all other URLs will be unprotected.
+	if isDefined(c.NonSecurePaths) && isDefined(c.SecurePaths) {
+		fmt.Println("Only non-secure URLs will be unprotected, all other URLs will treated as secured")
+	}
+
 	return nil
+}
+
+func isDefined(arr []string) bool {
+	return arr != nil
 }
 
 func isEmpty(str string) bool {


### PR DESCRIPTION
## Purpose
> Secured paths can be specified explicitly with the environment variable SECURE_PATHS, as comma separated values. Note that NON_SECURE_PATHS and SECURE_PATHS are mutually exclusive.
If both NON_SECURE_PATHS and SECURE_PATHS are specified, NON_SECURE_PATHS will be considered as open and everything else will be considered secured regardless of the value of SECURE_PATHS.