### PR TITLE
add base url to redirect urls in DCR call

### DIFF
--- a/components/envoy-oidc-filter/oidc/dcr.go
+++ b/components/envoy-oidc-filter/oidc/dcr.go
@@ -67,7 +67,7 @@ func dcr(c *Config) (string, string, error) {
 	}
 
 	values := map[string]interface{}{"client_name": c.ClientID, "grant_types": []string{"password",
-		"authorization_code", "implicit"}, "ext_param_client_id": c.ClientID, "redirect_uris": []string{c.RedirectURL}}
+		"authorization_code", "implicit"}, "ext_param_client_id": c.ClientID, "redirect_uris": []string{c.RedirectURL, c.BaseURL}}
 
 	payload, err := json.Marshal(values)
 	if err != nil {


### PR DESCRIPTION
## Purpose
> Add base url to redirect urls in the DCR request to IDP.