### PR TITLE
Disable docker plugin to avoid release build failure

### DIFF
--- a/docker/sts/pom.xml
+++ b/docker/sts/pom.xml
@@ -60,22 +60,22 @@
             </plugin>
 
             <!--Build Docker image-->
-            <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
-                <version>${maven.docker.version}</version>
-                <executions>
-                    <execution>
-                        <id>default</id>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                        <configuration>
-                            <repository>${docker.repo.name}/cell-sts</repository>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+            <!--<plugin>-->
+                <!--<groupId>com.spotify</groupId>-->
+                <!--<artifactId>dockerfile-maven-plugin</artifactId>-->
+                <!--<version>${maven.docker.version}</version>-->
+                <!--<executions>-->
+                    <!--<execution>-->
+                        <!--<id>default</id>-->
+                        <!--<goals>-->
+                            <!--<goal>build</goal>-->
+                        <!--</goals>-->
+                        <!--<configuration>-->
+                            <!--<repository>${docker.repo.name}/cell-sts</repository>-->
+                        <!--</configuration>-->
+                    <!--</execution>-->
+                <!--</executions>-->
+            <!--</plugin>-->
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
## Purpose
> Release build fails in the deploy phase with the spotify maven plugin due to an incompatibility with the maven version.